### PR TITLE
Cleanup and adapt playground page

### DIFF
--- a/docs/app/playground/page.tsx
+++ b/docs/app/playground/page.tsx
@@ -35,7 +35,6 @@ import {
   ToolsList,
   ArtifactsList,
   CodeSandbox,
-  FeatureHighlights,
 } from "@/components/playground";
 
 export default function PlaygroundPage() {
@@ -260,28 +259,37 @@ export default function PlaygroundPage() {
                 onValueChange={setActiveTab}
                 className="flex flex-col h-full"
               >
-                <div className="border-b px-4 flex items-center justify-between">
-                  <TabsList className="h-12 bg-transparent">
-                    <TabsTrigger value="chat" className="gap-2">
+                <div className="border-b px-4 py-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                  <TabsList className="!flex flex-1 flex-wrap gap-2 bg-transparent p-0 min-h-[3rem] w-full lg:w-auto">
+                    <TabsTrigger
+                      value="chat"
+                      className="gap-2 flex-1 min-w-[140px] sm:min-w-0 sm:flex-initial"
+                    >
                       <MessageSquare className="w-4 h-4 shrink-0" />
                       Chat
                     </TabsTrigger>
-                    <TabsTrigger value="code" className="gap-2">
+                    <TabsTrigger
+                      value="code"
+                      className="gap-2 flex-1 min-w-[140px] sm:min-w-0 sm:flex-initial"
+                    >
                       <Terminal className="w-4 h-4 shrink-0" />
                       Code
                     </TabsTrigger>
-                    <TabsTrigger value="artifacts" className="gap-2">
+                    <TabsTrigger
+                      value="artifacts"
+                      className="gap-2 flex-1 min-w-[140px] sm:min-w-0 sm:flex-initial"
+                    >
                       <FileText className="w-4 h-4 shrink-0" />
                       Artifacts
                     </TabsTrigger>
                   </TabsList>
 
-                  <div className="flex items-center gap-3">
+                  <div className="flex flex-wrap items-center gap-3 w-full lg:w-auto">
                     <Select
                       value={selectedAgent}
                       onValueChange={setSelectedAgent}
                     >
-                      <SelectTrigger className="w-[160px] h-8 text-sm">
+                      <SelectTrigger className="w-full sm:w-[160px] h-8 text-sm">
                         <SelectValue placeholder="Select agent" />
                       </SelectTrigger>
                       <SelectContent>
@@ -297,8 +305,11 @@ export default function PlaygroundPage() {
                         ))}
                       </SelectContent>
                     </Select>
-                    <Separator orientation="vertical" className="h-5" />
-                    <div className="flex items-center gap-2">
+                    <Separator
+                      orientation="vertical"
+                      className="h-6 hidden sm:block"
+                    />
+                    <div className="flex items-center gap-2 w-full sm:w-auto justify-between sm:justify-start">
                       <Switch
                         checked={streamingEnabled}
                         onCheckedChange={setStreamingEnabled}
@@ -361,10 +372,6 @@ export default function PlaygroundPage() {
           </div>
         </div>
 
-        {/* Feature Highlights */}
-        <div className="max-w-[1800px] mx-auto px-4 pb-8">
-          <FeatureHighlights />
-        </div>
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
Remove feature highlight blocks and make playground tabs responsive to improve page clarity and mobile usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-716e7750-44ee-4ee7-bef9-5f141e78708c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-716e7750-44ee-4ee7-bef9-5f141e78708c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the playground tab bar and control panel responsive and removes the feature highlights section.
> 
> - **UI (docs/app/playground/page.tsx)**
>   - **Responsive header:** Reworks the tabs header to wrap on small screens with flexible `TabsList`/`TabsTrigger` sizing and layout.
>     - Adds flex-wrap, min-widths for triggers, and adjusts container spacing/alignment.
>     - Makes agent `SelectTrigger` width responsive; hides vertical `Separator` on small screens.
>     - Adjusts Stream switch container to align and space responsively.
>   - **Removal:** Drops `FeatureHighlights` import and its section at the bottom of the page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7275533e0eadbf6217f569f4bc09bc40ae9cbb45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->